### PR TITLE
Fix functionality

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -21,20 +21,6 @@ chrome.storage.onChanged.addListener(function (changes) {
 	setState(changes.isOn.newValue)
 })
 
-function debounce(func, delay) {
-	let timeoutId
-
-	return function () {
-		const context = this
-		const args = arguments
-		clearTimeout(timeoutId)
-
-		timeoutId = setTimeout(() => {
-			func.apply(context, args)
-		}, delay)
-	}
-}
-
 function handleElementsInView(selector, callback) {
 	document.querySelectorAll(selector).forEach((element) => {
 		callback(element)
@@ -50,7 +36,8 @@ function removeCollections() {
 	)
 }
 
-// looks for collections on scroll & load
-window.addEventListener("scroll", debounce(removeCollections, 50))
-
+// looks for collections on load
 setTimeout(removeCollections, 200)
+
+// Autoremove every 100ms to handle dynamic modals
+setInterval(removeCollections, 100)

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,4 +1,4 @@
-// Si premier lancement, ajoute isOn
+// If first launch, add isOn
 chrome.storage.local.get(["isOn"], function (result) {
 	if (result.isOn === undefined)
 		chrome.storage.local.set({
@@ -11,12 +11,12 @@ function setState(state) {
 	else document.body.classList.remove("unminus")
 }
 
-// ajout .unminus au body si activé
+// add .unminus to body if enabled
 chrome.storage.local.get(["isOn"], function (result) {
 	setState(result.isOn)
 })
 
-// ajout .unminus au body à chaque changement de .isOn
+// add .unminus to body on every change of .isOn
 chrome.storage.onChanged.addListener(function (changes) {
 	setState(changes.isOn.newValue)
 })

--- a/extension/content.js
+++ b/extension/content.js
@@ -42,11 +42,12 @@ function handleElementsInView(selector, callback) {
 }
 
 function removeCollections() {
-	handleElementsInView('div[data-test="collection-feed-card"]', (element) => {
-		if (element.querySelector(".WZO3o").innerHTML.includes("Unsplash+")) {
+	handleElementsInView(
+		'figure:has(img[src^="https://plus.unsplash.com"])',
+		(element) => {
 			element.classList.add("hidden")
 		}
-	})
+	)
 }
 
 // looks for collections on scroll & load

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "Minus for Unsplash · Remove Unsplash+",
 	"short_name": "Minus for Unsplash",
-	"version": "1.5",
+	"version": "1.6",
 	"description": "Minus for Unsplash is a simple addon that lets you hide the Unsplash+ content from Unsplash.",
 	"author": "Tahoe Beetschen",
 

--- a/extension/manifest_firefox.json
+++ b/extension/manifest_firefox.json
@@ -28,7 +28,7 @@
 	"name": "Minus for Unsplash · Remove Unsplash+",
 	"permissions": ["storage"],
 	"short_name": "Minus for Unsplash",
-	"version": "1.5",
+	"version": "1.6",
 	"browser_specific_settings": {
 		"gecko": {
 			"id": "{81ccc223-67a9-4b53-9345-b85b5c6c8748}",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "minus-for-unsplash",
-	"version": "1.5",
+	"version": "1.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "minus-for-unsplash",
-	"version": "1.5",
+	"version": "1.6",
 	"description": "Minus for Unsplash is a simple addon that lets you hide the Unsplash+ content from Unsplash.",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
### Problem
The old CSS selector wasn't working anymore. Also the filter would not work in a modal (after clicking on a picture and scrolling), because the scrolling-listener would not be triggered.

### What this does
Fixes the selector to work like intended. It filters for the link now. Should be way more robust!
Also it refreshes every 100ms now, because scrolling listener was unreliable.